### PR TITLE
Logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Dependencies are specified in the `requirements.txt` file as usual.
 
 ## Usage examples
 
+The logo for the watermark has to be a `png` file with trasparency (otherwise
+the result would not be so good...but it's you choice).
+
 Go inside the `watermark` folder and:
 
 
@@ -29,6 +32,15 @@ Go inside the `watermark` folder and:
   string `res` to the output file:
 
     python watermark.py -s res -r -m 2000 ciccibalicci.jpg
+
+- Resize the file `ciccibalicci.jpg` to a maximum of 2100 pixels using the png
+  at the specified path:
+
+    python watermark.py -r -m 2100 -l "images/logo/Custom_Logo.png" ciccibalicci.jpg
+
+Just use `python watermark.py -h` to show the help.
+
+
 
 
 ### DPI

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Go inside the `watermark` folder and:
     python watermark.py -s res -r -m 2000 ciccibalicci.jpg
 
 
+### DPI
+
+If you don't specify the `-p` flag, all the processed images will be
+scaled to 150dpi. If you use `-p` they will be at 300dpi.
+
+
 #### Notes
 
 This software grew up as a personal command-line tool to help me in my workflow

--- a/watermark/watermark.py
+++ b/watermark/watermark.py
@@ -61,12 +61,14 @@ class ScriptConf():
             dest_path="watermarked/",
             image_quality=95,
             max_size=1700,
+            logo_path="images/logo/Arsenico13_White.png",
             ):
         self.margin = margin
         self.suffix = suffix
         self.dest_path = dest_path
         self.image_quality = image_quality
         self.max_size = max_size
+        self.LOGO = logo_path
 
 # LOGO_WHITE = "images/logo/Arsenico13_White.png"
 # LOGO_BLACK = "images/logo/Arsenico13_Black.png"
@@ -263,6 +265,13 @@ def main():
         type=str
     )
 
+    parser.add_argument(
+        '-l',
+        "--logo",
+        help="String. The path for the watermark png file.",
+        type=str
+    )
+
     args = parser.parse_args()
 
     suffix = "".join(["_", args.suffix]) if args.suffix else "_wm"
@@ -295,10 +304,12 @@ def main():
 
     image = args.image
 
+    if args.logo:
+        print(args.logo)
+        conf.LOGO = args.logo
+
     if args.black:
         conf.LOGO = "images/logo/Arsenico13_Black.png"
-    else:
-        conf.LOGO = "images/logo/Arsenico13_White.png"
 
     if os.path.isfile(image):
         # Watermark di una singola immagine


### PR DESCRIPTION
Added a new argument: `-l / --logo`

You can now specify the path for the png file to use in watermarking the images.

This fixes the #5 issue.